### PR TITLE
fix font-family of code blocks

### DIFF
--- a/src/gitbook-azure.css
+++ b/src/gitbook-azure.css
@@ -498,7 +498,7 @@ table tr td:last-child {
 
 .CodeMirror {
     padding: 1rem;
-    font-family: "Source Code Pro", monospace;
+    font-family: var(--code-font-family);
 }
 
 .cm-s-inner .CodeMirror-gutters {

--- a/src/gitbook-slate.css
+++ b/src/gitbook-slate.css
@@ -439,7 +439,7 @@ table tr td:last-child {
 
 .CodeMirror {
     padding: 1rem;
-    font-family: "Source Code Pro", monospace;
+    font-family: var(--code-font-family);
 }
 
 .cm-s-inner .CodeMirror-gutters {

--- a/src/gitbook-teal.css
+++ b/src/gitbook-teal.css
@@ -494,7 +494,7 @@ table tr td:last-child {
 
 .CodeMirror {
     padding: 1rem;
-    font-family: "Source Code Pro", monospace;
+    font-family: var(--code-font-family);
 }
 
 .cm-s-inner .CodeMirror-gutters {


### PR DESCRIPTION
The `font-family` of code blocks wasn't using the variable `--code-font-family`, but I think it's designed to use that.